### PR TITLE
Npgsql 4.1.2 guid to string fix

### DIFF
--- a/src/PgsqlErrorLog.cs
+++ b/src/PgsqlErrorLog.cs
@@ -179,10 +179,10 @@ namespace Elmah.Pgsql
                     {
                         while (reader.Read())
                         {
-                            var id = reader.GetString(0);
+                            var id = reader.GetGuid(0);
                             var xml = reader.GetString(1);
                             var error = ErrorXml.DecodeString(xml);
-                            errorEntryList.Add(new ErrorLogEntry(this, id, error));
+                            errorEntryList.Add(new ErrorLogEntry(this, id.ToString(), error));
                         }
                     }
                 }


### PR DESCRIPTION
#3 
Since npgsql is not able to read guid as strings directly, I changed the line to read the id as guid and add it as string to the ErrorLogEntry.